### PR TITLE
feat: 改进 ID3v2 元数据解析和图片处理

### DIFF
--- a/src/components/MusicHubComponent.ts
+++ b/src/components/MusicHubComponent.ts
@@ -381,10 +381,36 @@ export class MusicHubComponent {
 				coverImg.src = track.metadata.cover;
 				coverImg.alt = "专辑封面";
 
-				coverImg.onerror = () => {
+				// 添加加载状态指示
+				coverImg.style.opacity = "0";
+				coverImg.style.transition = "opacity 0.3s ease";
+
+				coverImg.onload = () => {
+					coverImg.style.opacity = "1";
+					console.log(
+						`Cover image loaded successfully for: ${track.name}`
+					);
+				};
+
+				coverImg.onerror = (e) => {
+					console.warn(
+						`Failed to load cover image for: ${track.name}`,
+						e
+					);
 					coverContainer.empty();
 					setIcon(coverContainer, ICONS.MUSIC);
 				};
+
+				// 设置加载超时
+				setTimeout(() => {
+					if (coverImg.style.opacity === "0" && coverImg.parentNode) {
+						console.warn(
+							`Cover image loading timed out for: ${track.name}`
+						);
+						coverContainer.empty();
+						setIcon(coverContainer, ICONS.MUSIC);
+					}
+				}, 5000);
 			} else {
 				setIcon(coverContainer, ICONS.MUSIC);
 			}


### PR DESCRIPTION
添加改进 MetadataParser 中的解析逻辑，增强对不同 ID3v2 版本、
扩展头和帧的鲁棒性；改进图片帧的描述解析与数据校验，并优化 Blob
创建与管理。

- 在解析开始处读取并记录 ID3v2 主/次版本和 flags，基于版本范围
  拒绝不支持的版本，避免误解析。
- 在存在扩展头时正确跳过扩展头长度以定位帧数据，记录 tag 大小与
  已解析帧数，增加帧计数器和上限防止无限循环。
- 根据文件头的主版本选择帧大小的读取方式：ID3v2.4 使用同步安全整
  数，旧版本使用普通 32 位整数，修复对不同版本帧长度的错误解读。
- 改进图片 (APIC) 帧解析：
  - 更准确地解析描述字段，分别处理单字节编码（ISO-8859-1/UTF-8）
    与双字节编码（UTF-16）的终止符；
  - 在提取图片数据前检查边界并验证图片数据完整性，检测常见图像魔术
    字节（JPEG/PNG 等），对可疑数据发出警告并放弃无效图片，减少崩溃
    或错误渲染的风险。
- 优化 Blob 创建：
  - 直接使用原始 Uint8Array 创建 Blob，避免不必要的内存复制；
  - 将生成的 blobUrl 与 Blob 映射保存以便日后清理；
  - 添加日志以便调试 Blob 创建与帧解析过程。

这些更改提升了解析的兼容性与健壮性，减少对损坏或非标准 tag 的误
处理，并改进图片提取的可靠性与资源管理。