### PR TITLE
chore: Bump 插件版本到 0.0.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "albus-status-bar-music",
 	"name": "Status Bar Music",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"minAppVersion": "0.15.0",
 	"description": "状态栏音乐播放器",
 	"author": "Albus",


### PR DESCRIPTION
更新 manifest.json 中的 version 字段从 0.0.1 到 0.0.2。
为发布或测试新改动准备新版本号，确保应用商店/用户
能够识别并获取最新改动。